### PR TITLE
Fix broken link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,4 +69,5 @@ overlay.
 .. _hackport: http://github.com/gentoo-haskell/hackport
 .. _projects listed on the hackage site:
     http://hackage.haskell.org/packages/archive/pkg-list.html
-.. _HOWTO contribute: projects/doc/HOWTO-contribute.rst
+.. _HOWTO contribute:
+    https://github.com/gentoo-haskell/gentoo-haskell/blob/master/projects/doc/HOWTO-contribute.rst


### PR DESCRIPTION
I first tried to use some relative URL, but this does not work reliable
(see github/markup#84).gentoo-haskell